### PR TITLE
Add Package.swift for SwiftPM support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let tag = "0.0.108"
+let checksum = "3d2f98a1c81b3124c92dfa8a515cf69658c6513b089e86de72425b4d228b18d0"
+let url = "https://github.com/lightningdevkit/ldk-swift/releases/download/\(tag)/LDKFramework.xcframework.zip"
+
+let package = Package(
+    name: "LDKFramework",
+    platforms: [
+        .iOS(.v13),
+        .macOS(.v10_12)
+    ],
+    products: [
+        .library(
+            name: "LDKFramework",
+            targets: ["LDKFramework"]
+        )
+    ],
+    targets: [
+        .binaryTarget(
+            name: "LDKFramework",
+            url: url,
+            checksum: checksum
+        )
+    ]
+)


### PR DESCRIPTION
Resolves #16.

I currently implemented this to only deal with `LDKFramework`. Ignores `no-macos`, `no-simulator`, `only-macos`. 

You can try dropping it in a sample project with my [fork](https://github.com/jurvis/ldk-swift), and specify the `jurvis/swiftpm` branch.

Here are some screenshots:
<img width="1971" alt="image" src="https://user-images.githubusercontent.com/5944973/163518857-88035439-0787-4668-a057-b6779d161a40.png">
<img width="1971" alt="image" src="https://user-images.githubusercontent.com/5944973/163518862-7c40ea1c-224f-4a9f-873a-b74efdfb9bd2.png">

However, while I was able to download the framework and import it just fine, it seems like there is an issue with visibility:
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/5944973/163519136-c4235a0f-a881-4bbb-8e7c-1a6739aefd8e.png">

 ## Other Notes
It looks like SwiftPM really does not like the `v` prefix. The interface is very opinionated, and things will only work as expected if we create tags **without** the `v` prefix. Something to consider.
<img width="483" alt="image" src="https://user-images.githubusercontent.com/5944973/163519074-cfd34dcc-f7f7-4a4a-80ce-f392dd2b4743.png">
