### PR TITLE
Wrap LDKCurrency in Swift enum

### DIFF
--- a/bindings/LDK/Bindings.swift
+++ b/bindings/LDK/Bindings.swift
@@ -6467,13 +6467,13 @@ withUnsafePointer(to: Bindings.array_to_tuple32(array: random_seed_bytes)) { (ra
         return LDKStr(chars: nativeType, len: UInt(string.count), chars_is_owned: chars_is_owned)
     }
 
-    public class func createInvoiceFromChannelManager(channelManager: ChannelManager, keysManager: KeysInterface, network: LDKCurrency, amountMsat: UInt64?, description: String) -> Result_InvoiceSignOrCreationErrorZ {
+    public class func createInvoiceFromChannelManager(channelManager: ChannelManager, keysManager: KeysInterface, network: LDKCurrencyType, amountMsat: UInt64?, description: String) -> Result_InvoiceSignOrCreationErrorZ {
 		let nativeKeysManager = keysManager.cOpaqueStruct!
 		let amount = Option_u64Z(value: amountMsat)
 		let nativeAmount = amount.cOpaqueStruct!
 		let nativeDescription = Self.new_LDKStr(string: description)
 		return withUnsafePointer(to: channelManager.cOpaqueStruct!) { (pointer: UnsafePointer<LDKChannelManager>) -> Result_InvoiceSignOrCreationErrorZ in
-			let nativeResult = create_invoice_from_channelmanager(pointer, nativeKeysManager, network, nativeAmount, nativeDescription)
+			let nativeResult = create_invoice_from_channelmanager(pointer, nativeKeysManager, network.ldkCurrency, nativeAmount, nativeDescription)
 			return Result_InvoiceSignOrCreationErrorZ(pointer: nativeResult)
 		}
 	}
@@ -6488,11 +6488,10 @@ withUnsafePointer(to: Bindings.array_to_tuple32(array: random_seed_bytes)) { (ra
 		}
 	}
 	*/
-	
-	public class func get_ldk_swift_bindings_version() -> String {
-        return "fe0ea5b41ca6eb7ef88a4d2fbd7dc1f647c89112"
-    }
 
+	public class func get_ldk_swift_bindings_version() -> String {
+        return "f579b1d12004f9917c8438994e0cdde707751d56"
+    }
 }
 
 public class InstanceCrashSimulator: NativeTypeWrapper {
@@ -6505,5 +6504,51 @@ public class InstanceCrashSimulator: NativeTypeWrapper {
         let pointer = Bindings.instanceToPointer(instance: self)
         return pointer
     }
+}
 
+public enum LDKCurrencyType {
+    case bitcoin
+	case bitcoinTestnet
+	case regtest
+	case simnet
+	case signet
+	case sentinel
+}
+
+extension LDKCurrencyType {
+	init(_ currency: LDKCurrency) {
+		switch currency {
+		case LDKCurrency_Bitcoin:
+			self = .bitcoin
+		case LDKCurrency_BitcoinTestnet:
+            self = .bitcoinTestnet
+		case LDKCurrency_Regtest:
+            self = .regtest
+		case LDKCurrency_Simnet:
+			self = .simnet
+		case LDKCurrency_Signet:
+			self = .signet
+		case LDKCurrency_Sentinel:
+			self = .sentinel
+        default:
+            self = .bitcoin
+        }
+	}
+
+	var ldkCurrency: LDKCurrency {
+		switch self {
+		case .bitcoin:
+			return LDKCurrency_Bitcoin
+		case .bitcoinTestnet:
+			return LDKCurrency_BitcoinTestnet
+		case .regtest:
+			return LDKCurrency_Regtest
+		case .signet:
+			return LDKCurrency_Signet
+		case .sentinel:
+			return LDKCurrency_Sentinel
+        case .simnet:
+            return LDKCurrency_Simnet
+        }
+	}
 }

--- a/bindings/LDK/options/Bech32Error.swift
+++ b/bindings/LDK/options/Bech32Error.swift
@@ -57,40 +57,6 @@ public class Bech32Error: NativeTypeWrapper {
 					}
 				
 			
-    public func clone() -> Bech32Error {
-    	
-        return Bech32Error(pointer: withUnsafePointer(to: self.cOpaqueStruct!) { (origPointer: UnsafePointer<LDKBech32Error>) in
-Bech32Error_clone(origPointer)
-});
-    }
-
-					internal func danglingClone() -> Bech32Error {
-        				let dangledClone = self.clone()
-						dangledClone.dangling = true
-						return dangledClone
-					}
-				
-
-    internal func free() -> Void {
-    	
-        return Bech32Error_free(self.cOpaqueStruct!);
-    }
-
-					internal func dangle() -> Bech32Error {
-        				self.dangling = true
-						return self
-					}
-					
-					deinit {
-						if !self.dangling {
-							Bindings.print("Freeing Bech32Error \(self.instanceNumber).")
-							self.free()
-						} else {
-							Bindings.print("Not freeing Bech32Error \(self.instanceNumber) due to dangle.")
-						}
-					}
-				
-
     /* OPTION_METHODS_END */
 
 	/* TYPE_CLASSES */

--- a/bindings/LDK/options/ParseError.swift
+++ b/bindings/LDK/options/ParseError.swift
@@ -120,7 +120,7 @@ ParseError_clone(origPointer)
 
     public class func bech32_error(a: Bech32Error) -> ParseError {
     	
-        return ParseError(pointer: ParseError_bech32_error(a.danglingClone().cOpaqueStruct!));
+        return ParseError(pointer: ParseError_bech32_error(a.cOpaqueStruct!));
     }
 
     public class func malformed_signature(a: LDKSecp256k1Error) -> ParseError {

--- a/templates/BindingsTemplate.swift
+++ b/templates/BindingsTemplate.swift
@@ -376,13 +376,13 @@ public class Bindings {
         return LDKStr(chars: nativeType, len: UInt(string.count), chars_is_owned: chars_is_owned)
     }
 
-    public class func createInvoiceFromChannelManager(channelManager: ChannelManager, keysManager: KeysInterface, network: LDKCurrency, amountMsat: UInt64?, description: String) -> Result_InvoiceSignOrCreationErrorZ {
+    public class func createInvoiceFromChannelManager(channelManager: ChannelManager, keysManager: KeysInterface, network: LDKCurrencyType, amountMsat: UInt64?, description: String) -> Result_InvoiceSignOrCreationErrorZ {
 		let nativeKeysManager = keysManager.cOpaqueStruct!
 		let amount = Option_u64Z(value: amountMsat)
 		let nativeAmount = amount.cOpaqueStruct!
 		let nativeDescription = Self.new_LDKStr(string: description)
 		return withUnsafePointer(to: channelManager.cOpaqueStruct!) { (pointer: UnsafePointer<LDKChannelManager>) -> Result_InvoiceSignOrCreationErrorZ in
-			let nativeResult = create_invoice_from_channelmanager(pointer, nativeKeysManager, network, nativeAmount, nativeDescription)
+			let nativeResult = create_invoice_from_channelmanager(pointer, nativeKeysManager, network.ldkCurrency, nativeAmount, nativeDescription)
 			return Result_InvoiceSignOrCreationErrorZ(pointer: nativeResult)
 		}
 	}
@@ -414,5 +414,51 @@ public class InstanceCrashSimulator: NativeTypeWrapper {
         let pointer = Bindings.instanceToPointer(instance: self)
         return pointer
     }
+}
 
+public enum LDKCurrencyType {
+    case bitcoin
+	case bitcoinTestnet
+	case regtest
+	case simnet
+	case signet
+	case sentinel
+}
+
+extension LDKCurrencyType {
+	init(_ currency: LDKCurrency) {
+		switch currency {
+		case LDKCurrency_Bitcoin:
+			self = .bitcoin
+		case LDKCurrency_BitcoinTestnet:
+            self = .bitcoinTestnet
+		case LDKCurrency_Regtest:
+            self = .regtest
+		case LDKCurrency_Simnet:
+			self = .simnet
+		case LDKCurrency_Signet:
+			self = .signet
+		case LDKCurrency_Sentinel:
+			self = .sentinel
+        default:
+            self = .bitcoin
+        }
+	}
+
+	var ldkCurrency: LDKCurrency {
+		switch self {
+		case .bitcoin:
+			return LDKCurrency_Bitcoin
+		case .bitcoinTestnet:
+			return LDKCurrency_BitcoinTestnet
+		case .regtest:
+			return LDKCurrency_Regtest
+		case .signet:
+			return LDKCurrency_Signet
+		case .sentinel:
+			return LDKCurrency_Sentinel
+        case .simnet:
+            return LDKCurrency_Simnet
+        }
+	}
 }

--- a/xcode/DirectBindingsApp/DirectBindingsApp.xcodeproj/project.pbxproj
+++ b/xcode/DirectBindingsApp/DirectBindingsApp.xcodeproj/project.pbxproj
@@ -729,6 +729,7 @@
 		07BBCE7726D03B49000D96C4 /* TestBroadcasterInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07BBCE6726D03B49000D96C4 /* TestBroadcasterInterface.swift */; };
 		07C753E126D6BE4E00081BF8 /* HumanObjectPeerTestInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C753DF26D6BE4E00081BF8 /* HumanObjectPeerTestInstance.swift */; };
 		07C753F326D9560200081BF8 /* PromiseKit in Frameworks */ = {isa = PBXBuildFile; productRef = 07C753F226D9560200081BF8 /* PromiseKit */; };
+		2883B5462814BA5E00D36423 /* CombineUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F51749280E7903009A7D10 /* CombineUtils.swift */; };
 		28F5174A280E7903009A7D10 /* CombineUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28F51749280E7903009A7D10 /* CombineUtils.swift */; };
 		2DD11C86114C6827D6E338A2 /* BlockchainObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 076D2A6D28039ACB00970AFC /* BlockchainObserver.swift */; };
 		2DD11F1338488839D8955B7A /* PolarIntegrationTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2DD1172C8DF0B244CF69B0FA /* PolarIntegrationTest.swift */; };
@@ -2499,6 +2500,7 @@
 				076D251027FC219300970AFC /* BuiltCommitmentTransaction.swift in Sources */,
 				076D23F227FC219100970AFC /* Result_PayeePubKeyErrorZ.swift in Sources */,
 				076D237627FC219100970AFC /* Result_PublicKeyErrorZ.swift in Sources */,
+				2883B5462814BA5E00D36423 /* CombineUtils.swift in Sources */,
 				076D22D027FC219000970AFC /* BroadcasterInterface.swift in Sources */,
 				076D23E027FC219100970AFC /* Result_ReplyChannelRangeDecodeErrorZ.swift in Sources */,
 				076D231627FC219000970AFC /* Result_QueryChannelRangeDecodeErrorZ.swift in Sources */,

--- a/xcode/DirectBindingsApp/DirectBindingsAppTests/HumanObjectPeerTestInstance.swift
+++ b/xcode/DirectBindingsApp/DirectBindingsAppTests/HumanObjectPeerTestInstance.swift
@@ -549,7 +549,7 @@ public class HumanObjectPeerTestInstance {
         do {
             // create invoice for 10k satoshis to pay to peer2
             
-            let invoiceResult = Bindings.createInvoiceFromChannelManager(channelManager: peer2.channelManager, keysManager: peer2.keysInterface, network: LDKCurrency_Bitcoin, amountMsat: SEND_MSAT_AMOUNT_A_TO_B, description: "Invoice description")
+            let invoiceResult = Bindings.createInvoiceFromChannelManager(channelManager: peer2.channelManager, keysManager: peer2.keysInterface, network: .bitcoin, amountMsat: SEND_MSAT_AMOUNT_A_TO_B, description: "Invoice description")
             let invoice = invoiceResult.getValue()!
             print("Invoice: \(invoice.to_str())")
             
@@ -625,7 +625,7 @@ public class HumanObjectPeerTestInstance {
             print("pre-payment balance A->B mSats: \(prePaymentBalanceAToB)")
             print("pre-payment balance B->A mSats: \(prePaymentBalanceBToA)")
             
-            let invoiceResult = Bindings.createInvoiceFromChannelManager(channelManager: peer1.channelManager, keysManager: peer1.keysInterface, network: LDKCurrency_Bitcoin, amountMsat: nil, description: "Second invoice description")
+            let invoiceResult = Bindings.createInvoiceFromChannelManager(channelManager: peer1.channelManager, keysManager: peer1.keysInterface, network: .bitcoin, amountMsat: nil, description: "Second invoice description")
             let invoice = invoiceResult.getValue()!
             print("Implicit amount invoice: \(invoice.to_str())")
             


### PR DESCRIPTION
## Purpose
Make API for creating an invoice a little nicer. So instead of calling `Bindings.createInvoiceFromChannelManager(channelManager: channelManager, keysManager: keysManager.as_KeysInterface(), network: LDKCurrency_Regtest, amountMsat: amtMsat, description: description)` where we pass in a C-style enum, allow for a nicer Swifty API:

`Bindings.createInvoiceFromChannelManager(channelManager: channelManager, keysManager: keysManager.as_KeysInterface(), network: .regtest, amountMsat: amtMsat, description: description)`

This also fixes tests failing to run because `CombineUtils` wasn't included in the test target.

## Implementation
1. Added `LDKCurrencyType` enum to template
2. Changed method signature to take in `LDKCurrencyType` instead of `LDKCurrency`
3. Add extension to `LDKCurrencyType` enum that will return the c-style enum for `create_invoice_from_channelmanager`