### PR TITLE
Only build iOS Framework on arm64 Macs

### DIFF
--- a/xcode/build_framework.sh
+++ b/xcode/build_framework.sh
@@ -7,36 +7,41 @@ popd
 
 pushd ./LDKFramework
 
-# xcodebuild -list
-
+# Build for both iOS and iOS Simulator
 xcodebuild archive -scheme LDKFramework -destination "generic/platform=iOS" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS ENABLE_BITCODE=NO CLANG_ADDRESS_SANITIZER=NO CLANG_ADDRESS_SANITIZER_ALLOW_ERROR_RECOVERY=NO CLANG_ADDRESS_SANITIZER_USE_AFTER_SCOPE=NO SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 xcodebuild archive -scheme LDKFramework -destination "generic/platform=iOS Simulator" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-Sim CLANG_ADDRESS_SANITIZER=NO CLANG_ADDRESS_SANITIZER_ALLOW_ERROR_RECOVERY=NO CLANG_ADDRESS_SANITIZER_USE_AFTER_SCOPE=NO SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
-# xcodebuild archive -scheme LDKFramework-Mac -destination "generic/platform=OS X" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-
 popd
 
-pushd ./LDKFramework_Mac
-# xcodebuild archive -scheme LDKFramework -destination "platform=macOS,arch=x86_64,variant=Mac Catalyst" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS CLANG_ADDRESS_SANITIZER=YES ONLY_ACTIVE_ARCH=YES SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-xcodebuild archive -scheme LDKFramework -destination "platform=macOS,arch=x86_64,variant=Mac Catalyst" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS ENABLE_BITCODE=NO ONLY_ACTIVE_ARCH=YES SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-popd
+ARCH=$(uname -m)
+if [ "$ARCH" != "arm64" ]; then
+    pushd ./LDKFramework_Mac
+    xcodebuild archive -scheme LDKFramework -destination "platform=macOS,arch=x86_64,variant=Mac Catalyst" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS ENABLE_BITCODE=NO ONLY_ACTIVE_ARCH=YES SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+    popd
 
-xcodebuild -create-xcframework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-Sim.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--output ${BIN_OUTPUT_DIRECTORY}/LDKFramework.xcframework
+    xcodebuild -create-xcframework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-Sim.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -output ${BIN_OUTPUT_DIRECTORY}/LDKFramework.xcframework
 
-xcodebuild -create-xcframework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-Sim.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--output ${BIN_OUTPUT_DIRECTORY}/LDKFramework-no-macOS.xcframework
+    xcodebuild -create-xcframework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -output ${BIN_OUTPUT_DIRECTORY}/LDKFramework-no-simulator.xcframework
 
-xcodebuild -create-xcframework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--output ${BIN_OUTPUT_DIRECTORY}/LDKFramework-only-macOS.xcframework
 
-xcodebuild -create-xcframework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
--output ${BIN_OUTPUT_DIRECTORY}/LDKFramework-no-simulator.xcframework
+    xcodebuild -create-xcframework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -output ${BIN_OUTPUT_DIRECTORY}/LDKFramework-only-macOS.xcframework
+
+    xcodebuild -create-xcframework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-Sim.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -output ${BIN_OUTPUT_DIRECTORY}/LDKFramework-no-macOS.xcframework
+else
+    xcodebuild -create-xcframework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-Sim.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
+        -output ${BIN_OUTPUT_DIRECTORY}/LDKFramework.xcframework
+fi

--- a/xcode/build_framework.sh
+++ b/xcode/build_framework.sh
@@ -5,18 +5,6 @@ BIN_OUTPUT_DIRECTORY=`pwd`
 rm -rf LDKFramework*
 popd
 
-
-## experimental only
-#pushd ./LDKFramework_Mac
-#xcodebuild archive -scheme LDKFramework -destination "platform=macOS,arch=x86_64,variant=Mac Catalyst" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS ENABLE_BITCODE=NO ONLY_ACTIVE_ARCH=YES SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-#popd
-##xcodebuild -create-xcframework \
-##-framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \
-##-output ${BIN_OUTPUT_DIRECTORY}/LDKFramework-only-simulator.xcframework
-#exit 0
-
-
-
 pushd ./LDKFramework
 
 # xcodebuild -list
@@ -28,16 +16,10 @@ xcodebuild archive -scheme LDKFramework -destination "generic/platform=iOS Simul
 
 popd
 
-
 pushd ./LDKFramework_Mac
 # xcodebuild archive -scheme LDKFramework -destination "platform=macOS,arch=x86_64,variant=Mac Catalyst" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS CLANG_ADDRESS_SANITIZER=YES ONLY_ACTIVE_ARCH=YES SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 xcodebuild archive -scheme LDKFramework -destination "platform=macOS,arch=x86_64,variant=Mac Catalyst" -archivePath ${BIN_OUTPUT_DIRECTORY}/LDKFramework-macOS ENABLE_BITCODE=NO ONLY_ACTIVE_ARCH=YES SKIP_INSTALL=NO BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 popd
-
-
-
-
-# disable mac and simulator compilation for the time being
 
 xcodebuild -create-xcframework \
 -framework ${BIN_OUTPUT_DIRECTORY}/LDKFramework-iOS.xcarchive/Products/Library/Frameworks/LDKFramework.framework \

--- a/xcode/compile_dependency_binaries.sh
+++ b/xcode/compile_dependency_binaries.sh
@@ -31,31 +31,14 @@ python3 ../ci/fix_header_includes.py $DIRECT_BINDINGS_PROJECT_DIRECTORY
 
 # build for Catalyst
 pushd $C_BINDINGS_SOURCE_DIRECTORY
-#export RUSTFLAGS=""
-#export RUSTFLAGS="-Z sanitizer=address"
-#export RUSTFLAGS="--cfg=c_bindings --cfg=feature=\"std\" --cfg=feature=\"bitcoin/std\" --cfg=feature=\"lightning/std\" --cfg=feature=\"lightning-invoice/std\""
 export RUSTFLAGS="--cfg=c_bindings"
-#export RUSTFLAGS="--cfg=c_bindings --cfg=feature=\"default\" --cfg=feature=\"std\""
-#export RUSTFLAGS="--cfg=c_bindings --cfg=feature=\"default\""
-#export RUSTFLAGS="--cfg=c_bindings -C lto=off -C embed-bitcode=no"
-#export RUSTFLAGS="--cfg=c_bindings -C lto=off -Z embed-bitcode"
 
-# sanity check
-#cargo rustc -- --print cfg
-#cargo build --target x86_64-apple-ios-macabi --release
-#exit
-
-# Mac ABI binary (disable temporarily) TODO: reenable
-# it might be necessary to run "sudo xcode-select --switch /Library/Developer/CommandLineTools" here
-# sudo xcode-select --switch /Library/Developer/CommandLineTools
 rustup override set nightly
 cargo clean
 cargo build -Z build-std=panic_abort,std --features "std" --target x86_64-apple-ios-macabi --release
 cp "${C_BINDINGS_SOURCE_DIRECTORY}/target/x86_64-apple-ios-macabi/release/libldk.a" $FRAMEWORK_PROJECT_DIRECTORY_MAC
 
 # iOS & Simulator binaries
-# it might be necessary to run "sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer"
-# sudo xcode-select --switch /Applications/Xcode.app/Contents/Developer
 rustup override unset
 cargo clean
 cargo lipo --features "std" --release

--- a/xcode/compile_dependency_binaries.sh
+++ b/xcode/compile_dependency_binaries.sh
@@ -28,26 +28,25 @@ python3 ../ci/fix_header_includes.py $FRAMEWORK_PROJECT_DIRECTORY_IOS
 python3 ../ci/fix_header_includes.py $FRAMEWORK_PROJECT_DIRECTORY_MAC
 python3 ../ci/fix_header_includes.py $DIRECT_BINDINGS_PROJECT_DIRECTORY
 
-
-# build for Catalyst
 pushd $C_BINDINGS_SOURCE_DIRECTORY
 export RUSTFLAGS="--cfg=c_bindings"
 
-rustup override set nightly
-cargo clean
-cargo build -Z build-std=panic_abort,std --features "std" --target x86_64-apple-ios-macabi --release
-cp "${C_BINDINGS_SOURCE_DIRECTORY}/target/x86_64-apple-ios-macabi/release/libldk.a" $FRAMEWORK_PROJECT_DIRECTORY_MAC
+# Build for Catalyst
+# Unfortunately, this only works for x86_64-based Macs for now, since the `aarch64-apple-ios-macabi` target
+# currently does not have the standard library supported.
+ARCH=$(uname -m)
+if [ "$ARCH" != "arm64" ]; then
+	rustup override set nightly
+	cargo clean
 
-# iOS & Simulator binaries
-rustup override unset
-cargo clean
+	cargo build -Z build-std=panic_abort,std --features "std" --target x86_64-apple-ios-macabi --release
+	cp "${C_BINDINGS_SOURCE_DIRECTORY}/target/x86_64-apple-ios-macabi/release/libldk.a" $FRAMEWORK_PROJECT_DIRECTORY_MAC
+
+	rustup override unset
+	cargo clean
+fi
+
 cargo lipo --features "std" --release
 cp "${C_BINDINGS_SOURCE_DIRECTORY}/target/universal/release/libldk.a" $FRAMEWORK_PROJECT_DIRECTORY_IOS
 cargo lipo --features "std"
 cp "${C_BINDINGS_SOURCE_DIRECTORY}/target/universal/debug/libldk.a" $DIRECT_BINDINGS_PROJECT_DIRECTORY
-
-
-
-
-
-


### PR DESCRIPTION
Currently, because rustc does not formally support `arm64` catalyst targets, the build scripts at their current state fails on an Apple Silicon Mac.

We should check a user's current architecture, and adjust build behaviors accordingly.