### PR TITLE
SPM 0.0.108 release fix

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 let tag = "0.0.108"
-let checksum = "e69f12f9eb3335864ccd336d1285ec5e90826d68ca94594958aa61281af3ef84"
+let checksum = "01eb13d93f90ae228130ad17b2dffe8388611886125f8dd53ba2d31518209f92"
 let url = "https://github.com/lightningdevkit/ldk-swift/releases/download/\(tag)/LDKFramework.xcframework.zip"
 
 let package = Package(


### PR DESCRIPTION
It looks like the checksum of the `xcframework` produced changes _between_ builds. 

The trouble with that is we cannot anticipate the checksum by building an `xcframework` locally and updating `Package.swift` ahead of Github Actions creating the release `xcframework` for us.

The release process looks like it needs to be:
1. Tag version to commit. Say, `0.0.108`
2. Let GitHub Actions build and create the release
3. Download `xcframework` from release, and then run `swift package compute-checksum /path/to/LDKFramework.xcframework.zip`
4. Update `Package.swift` with checksum calculated in 3
5. Create a new commit for updating said checksum in `Package.swift`
6. Move tag to latest commit created in 5.

This PR serves as essentially step 4-5 of our process articulated above. I grabbed the checksum of our release [here](https://github.com/lightningdevkit/ldk-swift/releases/tag/0.0.108), and ran `swift package compute-checksum` on it.

We should probably get someone to make sure that it is indeed `01eb13d93f90ae228130ad17b2dffe8388611886125f8dd53ba2d31518209f92` before merging. Then, we'll just have to move, **not retag** `0.0.108`. 