### PR TITLE
Use multiple artifacts for parallel xcarchive builds.

### DIFF
--- a/.github/workflows/build-xcframework-parallel-archives.yml
+++ b/.github/workflows/build-xcframework-parallel-archives.yml
@@ -55,8 +55,8 @@ jobs:
             -   name: Upload xcarchive
                 uses: actions/upload-artifact@v3
                 with:
-                    name: bindings
-                    path: ./bindings/**/bin/release/${{ matrix.configuration['human_readable_platform'] }}/${{ matrix.configuration['human_readable_platform'] }}.xcarchive
+                    name: ${{ matrix.configuration['human_readable_platform'] }}
+                    path: ./bindings/bin/release/${{ matrix.configuration['human_readable_platform'] }}/**/${{ matrix.configuration['human_readable_platform'] }}.xcarchive
 
     generate:
         name: Combine xcarchives into xcframework
@@ -74,6 +74,8 @@ jobs:
                 uses: actions/checkout@v2
             -   name: Download xcarchives
                 uses: actions/download-artifact@v3
+                with:
+                    path: ./bindings/bin/release/
             -   name: Generate xcframework
                 shell: bash
                 run:

--- a/.github/workflows/test-artifacts.yml
+++ b/.github/workflows/test-artifacts.yml
@@ -34,8 +34,8 @@ jobs:
             -   name: Upload emulated xcarchive
                 uses: actions/upload-artifact@v3
                 with:
-                    name: uploaded-artifact-name
-                    path: ./bindings/**/bin/release/${{ matrix.configuration['human_readable_platform'] }}/${{ matrix.configuration['human_readable_platform'] }}.xcarchive
+                    name: ${{ matrix.configuration['human_readable_platform'] }}
+                    path: ./bindings/bin/release/${{ matrix.configuration['human_readable_platform'] }}/**/${{ matrix.configuration['human_readable_platform'] }}.xcarchive
 
     download-artifact:
         name: Download artifact
@@ -47,8 +47,9 @@ jobs:
             -   name: Download emulated xcarchives
                 uses: actions/download-artifact@v3
                 with:
-                    path: ./downloaded-artifact-name
+                    path: ./bindings/bin/release/
             -   name: Preview download result
                 run: |
+                    cd ./bindings/bin/release
                     ls -ll -R
 


### PR DESCRIPTION
This reduces the size of the resulting artifact to the 31MB range, just like the other xcframework generation procedures.