### PR TITLE
Remove `DEVELOPER_DIR` envvar from Github Actions

### DIFF
--- a/.github/workflows/build-xcframework-parallel-archives.yml
+++ b/.github/workflows/build-xcframework-parallel-archives.yml
@@ -30,7 +30,6 @@ jobs:
                     -   destination: 'macOS,variant=Mac Catalyst'
                         human_readable_platform: 'catalyst'
         env:
-            DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
             LDK_C_BINDINGS_BASE: /Users/runner/work/ldk-swift/ldk-swift/bindings/artifacts/ldk-c-bindings
             LDK_C_BINDINGS_BINARY_DIRECTORY: /Users/runner/work/ldk-swift/ldk-swift/bindings/artifacts/bin
         steps:
@@ -63,7 +62,6 @@ jobs:
         runs-on: macos-12
         needs: [ build-xcarchives ]
         env:
-            DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
             LDK_C_BINDINGS_BASE: /Users/runner/work/ldk-swift/ldk-swift/bindings/artifacts/ldk-c-bindings
         steps:
             -   name: Configure Xcode

--- a/.github/workflows/build-xcframework-parallel-libldk.yml
+++ b/.github/workflows/build-xcframework-parallel-libldk.yml
@@ -18,7 +18,6 @@ jobs:
         name: Build & lipo libldk.a for ${{ matrix.configuration['human_readable_platform'] }}
         runs-on: macos-12
         env:
-            DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
             LDK_C_BINDINGS_BASE: /Users/runner/work/ldk-swift/ldk-swift/bindings/artifacts/ldk-c-bindings
         strategy:
             fail-fast: true
@@ -73,7 +72,6 @@ jobs:
         needs: [ build-libldks ]
         runs-on: macos-12
         env:
-            DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
             LDK_C_BINDINGS_BASE: /Users/runner/work/ldk-swift/ldk-swift/bindings/artifacts/ldk-c-bindings
         steps:
             -   name: Configure Xcode

--- a/.github/workflows/build-xcframework-sequential.yml
+++ b/.github/workflows/build-xcframework-sequential.yml
@@ -18,7 +18,6 @@ jobs:
         name: Build libldks, build xcarchives, and combine into xcframework
         runs-on: macos-12
         env:
-            DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
             LDK_C_BINDINGS_BASE: /Users/runner/work/ldk-swift/ldk-swift/bindings/artifacts/ldk-c-bindings
         steps:
             -   name: Configure Xcode

--- a/.github/workflows/direct-bindings-app-tests.yml
+++ b/.github/workflows/direct-bindings-app-tests.yml
@@ -31,8 +31,6 @@ jobs:
           platform: iOS Simulator
           project: DirectBindingsApp/DirectBindingsApp.xcodeproj
           xcode-unit-test: DirectBindingsAppTests
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_13.3.1.app/Contents/Developer
     steps:
     - name: Configure Xcode
       uses: maxim-lobanov/setup-xcode@v1

--- a/.github/workflows/release-framework.yml
+++ b/.github/workflows/release-framework.yml
@@ -18,7 +18,6 @@ jobs:
         name: Generate XCFramework
         runs-on: macos-12
         env:
-            DEVELOPER_DIR: /Applications/Xcode_13.2.1.app/Contents/Developer
             LDK_C_BINDINGS_BASE: /Users/runner/work/ldk-swift/ldk-swift/bindings/artifacts/ldk-c-bindings
         steps:
             -   name: Configure Xcode


### PR DESCRIPTION
We probably don't need this anymore since we hardcode the architecture for Mac Catalyst targets with the Python script, working around the bug in `cc`: https://github.com/rust-lang/cc-rs/issues/664