### PR TITLE
Test and fix non-init-based anchoring

### DIFF
--- a/ci/LDKSwift/Tests/LDKSwiftTests/HumanObjectPeerTestInstance.swift
+++ b/ci/LDKSwift/Tests/LDKSwiftTests/HumanObjectPeerTestInstance.swift
@@ -17,10 +17,11 @@ public class HumanObjectPeerTestInstance {
 
     public class Configuration {
 //
-        public var useFilter: Bool = false;
-        public var useRouter: Bool = false;
-        public var shouldRecipientRejectPayment: Bool = false;
+        public var useFilter: Bool = false
+        public var useRouter: Bool = false
+        public var shouldRecipientRejectPayment: Bool = false
         public var ephemeralNetworkGraphForScorer: Bool = false
+        public var reserializedProbabilisticScorer: Bool = false
 
         // public var nice_close: Bool = false;
         // public var use_km_wrapper: Bool = false;
@@ -30,7 +31,7 @@ public class HumanObjectPeerTestInstance {
         // public var use_nio_peer_handler: Bool = false;
 
         private class func listCustomizeableProperties() -> [String] {
-            return ["useFilter", "useRouter", "shouldRecipientRejectPayment", "ephemeralNetworkGraphForScorer"]
+            return ["useFilter", "useRouter", "shouldRecipientRejectPayment", "ephemeralNetworkGraphForScorer", "reserializedProbabilisticScorer"]
         }
 
         public class func combinationCount() -> UInt {
@@ -308,7 +309,12 @@ public class HumanObjectPeerTestInstance {
                 }
 
                 let scoringParams = ProbabilisticScoringParameters.initWithDefault()
-                let probabalisticScorer = ProbabilisticScorer(params: scoringParams, networkGraph: scorerGraph, logger: self.logger)
+                var probabalisticScorer = ProbabilisticScorer(params: scoringParams, networkGraph: scorerGraph, logger: self.logger)
+                if master.configuration.reserializedProbabilisticScorer {
+                    let serializedScorer = probabalisticScorer.write()
+                    let probabalisticScorerResult = ProbabilisticScorer.read(ser: serializedScorer, argA: scoringParams, argB: scorerGraph, argC: self.logger)
+                    probabalisticScorer = probabalisticScorerResult.getValue()!
+                }
                 let score = probabalisticScorer.asScore()
                 let multiThreadedScorer = MultiThreadedLockableScore(score: score)
                 

--- a/ci/LDKSwift/Tests/LDKSwiftTests/LDKSwiftTests.swift
+++ b/ci/LDKSwift/Tests/LDKSwiftTests/LDKSwiftTests.swift
@@ -472,6 +472,9 @@ class LDKSwiftTests: XCTestCase {
             
             config.ephemeralNetworkGraphForScorer = (i & (1 << 3)) != 0
             print("ephemeralNetworkGraphForScorer: \(config.ephemeralNetworkGraphForScorer)")
+            
+            config.reserializedProbabilisticScorer = (i & (1 << 4)) != 0
+            print("reserializedProbabilisticScorer: \(config.reserializedProbabilisticScorer)")
 
             let instance = HumanObjectPeerTestInstance(configuration: config)
             await instance.testMessageHandling()

--- a/out/Bindings.swift
+++ b/out/Bindings.swift
@@ -392,7 +392,8 @@
 					let returnValue = InitFeatures(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: config)
+return returnValue
 				}
 		
 				/// Equivalent to [`crate::ln::channelmanager::ChannelManager::create_inbound_payment`], but no
@@ -437,7 +438,8 @@
 					let returnValue = Result_C2Tuple_PaymentHashPaymentSecretZNoneZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: keys)
+return returnValue
 				}
 		
 				/// Equivalent to [`crate::ln::channelmanager::ChannelManager::create_inbound_payment_for_hash`],
@@ -478,7 +480,8 @@
 					let returnValue = Result_PaymentSecretNoneZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: keys)
+return returnValue
 				}
 		
 				/// Gets the weight for an HTLC-Success transaction.
@@ -1079,7 +1082,9 @@
 					let returnValue = Result_RouteLightningErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: routeParams)
+					try! returnValue.addAnchor(anchor: networkGraph)
+return returnValue
 				}
 		
 				/// Construct a route from us (payer) to the target node (payee) via the given hops (which should
@@ -1124,7 +1129,9 @@
 					let returnValue = Result_RouteLightningErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: routeParams)
+					try! returnValue.addAnchor(anchor: networkGraph)
+return returnValue
 				}
 		
 				/// Pays the given [`Invoice`], retrying if needed based on [`Retry`].
@@ -1157,7 +1164,9 @@
 					let returnValue = Result_PaymentIdPaymentErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: invoice)
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// Pays the given [`Invoice`] with a custom idempotency key, retrying if needed based on [`Retry`].
@@ -1197,7 +1206,9 @@
 					let returnValue = Result_NonePaymentErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: invoice)
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// Pays the given zero-value [`Invoice`] using the given amount, retrying if needed based on
@@ -1232,7 +1243,9 @@
 					let returnValue = Result_PaymentIdPaymentErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: invoice)
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// Pays the given zero-value [`Invoice`] using the given amount and custom idempotency key,
@@ -1274,7 +1287,9 @@
 					let returnValue = Result_NonePaymentErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: invoice)
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// Utility to create an invoice that can be paid to one of multiple nodes, or a \"phantom invoice.\"
@@ -1467,7 +1482,8 @@
 					let returnValue = Result_InvoiceSignOrCreationErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// Utility to construct an invoice. Generally, unless you want to do something like a custom
@@ -1509,7 +1525,8 @@
 					let returnValue = Result_InvoiceSignOrCreationErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// See [`create_invoice_from_channelmanager_with_description_hash`]
@@ -1538,7 +1555,8 @@
 					let returnValue = Result_InvoiceSignOrCreationErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// See [`create_invoice_from_channelmanager`]
@@ -1572,7 +1590,8 @@
 					let returnValue = Result_InvoiceSignOrCreationErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// See [`create_invoice_from_channelmanager_and_duration_since_epoch`]
@@ -1612,7 +1631,8 @@
 					let returnValue = Result_InvoiceSignOrCreationErrorZ(cType: nativeCallResult)
 					
 
-					return returnValue
+					try! returnValue.addAnchor(anchor: channelmanager)
+return returnValue
 				}
 		
 				/// Read a C2Tuple_BlockHashChannelMonitorZ from a byte array, created by C2Tuple_BlockHashChannelMonitorZ_write

--- a/out/structs/ProbabilisticScorer.swift
+++ b/out/structs/ProbabilisticScorer.swift
@@ -469,7 +469,8 @@
 						let returnValue = Result_ProbabilisticScorerDecodeErrorZ(cType: nativeCallResult)
 						
 
-						return returnValue
+						try! returnValue.addAnchor(anchor: argB)
+return returnValue
 					}
 		
 


### PR DESCRIPTION
One example is the NetworkGraph argument to ProbabilisticScorer.read.