### PR TITLE
fix: remove swiftsettings from binarytarget

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,7 @@ let package = Package(
         .binaryTarget(
             name: "LightningDevKit",
             url: url,
-            checksum: checksum,
-            swiftSettings: [.unsafeFlags(["-suppress-warnings"])]
+            checksum: checksum
         )
     ]
 )


### PR DESCRIPTION
### Description

Fixes #120.

### Notes to the reviewers

This fixes the reason for the error in #120.

<img width="1390" alt="Screenshot 2023-10-16 at 1 55 47 PM" src="https://github.com/lightningdevkit/ldk-swift/assets/6657488/c7880b29-3658-4a27-b574-72e3470efbe7">

**_I can follow up in an additional PR how to re-fix not showing the warnings that this code will re-introduce by removing `suppress-warnings` from `.binaryTarget`, but this PR's main goal is the fix the issue where a user can not use ldk-swift in their Xcode project, which was because of `suppress-warnings` in `.binaryTarget`._** Here is the warnings showing up:

<img width="1393" alt="Screenshot 2023-10-16 at 2 02 19 PM" src="https://github.com/lightningdevkit/ldk-swift/assets/6657488/8e71075a-6745-4632-8d7c-ab231e736ad7">

### Other Thoughts

Why did this error show in `.117` but not `.116`? This question still bugs me because I would like to have seen a specific changelog from Apple relating to this. From documentation I researched though, in the Swift Package Manager `swiftSettings` is a parameter that is specific to `.target` instances. From what I read binary targets don't have source files that need to be compiled, so they don't seem to have a `swiftSettings` parameter; so I'm guessing the `swiftSettings` parameter isn't supposed to be used with `.binaryTarget` it seems as per the design of the Swift Package Manager. It's possible that there might have been a change or a bug fix in the Swift Package Manager that now enforces this rule more strictly?

I also looked and tested across LDK Node + BDK Swift + LDK Swift, LDK Swift was the only dependency I was getting an error like this for and one of the main differences between the `Package.swift` in LDK Swift as compared to LDK Node and BDK Swift is that `suppressWarnings` was included in the `.binaryTarget` for LDK Swift but it was included in the `.target` for both LDK Node and BDK Swift.

- [LDK Node Package.swift](https://github.com/lightningdevkit/ldk-node/blob/main/Package.swift)
- [LDK Swift Package.swift](https://github.com/lightningdevkit/ldk-swift/blob/main/Package.swift)
- [BDK Swift Package.swift](https://github.com/bitcoindevkit/bdk-ffi/blob/master/bdk-swift/Package.swift)

So taking all of that into consideration, and also testing 2 things to make sure worked:
- removing the related line of code worked to remove the error on the ldk-swift when opened in Xcode
- creating a new Xcode project then added ldk-swift as a local dependency that had the fix included worked for adding the dependency

#### Submissions:

I did sign all my commits

I did not format my code per `.swift-format` since that change over 200+ files that were unrelated to my small code change.

I linked to the Issue this PR fixes.

### Draft PR

I will just put this PR in Draft mode for now.