### PR TITLE
package: add target to swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,12 @@ let package = Package(
         )
     ],
     targets: [
+        .target(
+            name: "LightningDevKitTarget",
+            dependencies: ["LightningDevKit"],
+            path: "./out",
+            swiftSettings: [.unsafeFlags(["-suppress-warnings"])]
+        ),
         .binaryTarget(
             name: "LightningDevKit",
             url: url,


### PR DESCRIPTION
_Draft: see Thoughts/Issues/Feedback/Before-Merging_

tl;dr this removes warnings in `ldk-swift`, but just some feedback needed.

## **Describe The Feature**

In PR #121 we removed `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]` due to Issue #120. 

This PR adds a `.target` that can now handle that `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]` line of code back into `ldk-swift` without re-creating the Issue #120.

## Why Add This Feature

We probably want the `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]` line somewhere because an end consumer of `ldk-swift` will show no warnings in their IDE instead of 1000+ without `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]`

<img width="838" alt="Screenshot 2023-10-19 at 11 05 56 AM" src="https://github.com/lightningdevkit/ldk-swift/assets/6657488/c0221841-212e-4f11-8325-ebfe85b8b84b">

## How This Feature Was Added

Instead of including `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]` in `.binaryTarget` it is included in `.target`.

For this a `.target` had to be added in the `Package.swift` file in the same `.targets` section that `.binaryTarget` is in.

## Thinking Around This Feature

[ldk-node](https://github.com/lightningdevkit/ldk-node/blob/main/Package.swift) + [bdk-ffi](https://github.com/bitcoindevkit/bdk-ffi/blob/master/bdk-swift/Package.swift) + [bdk-swift](https://github.com/bitcoindevkit/bdk-swift/blob/master/Package.swift) `Package.swift`'s all include a `.target` that the `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]` is used in, and testing this change in `ldk-swift` does what is expected by removing the warnings and not causing any errors.

<img width="1393" alt="Screenshot 2023-10-24 at 9 10 27 AM" src="https://github.com/lightningdevkit/ldk-swift/assets/6657488/44f7831d-b493-404e-8aa4-c4908eba2525">

## Thoughts/Issues/Feedback Before Merging

- No warnings is definitely nice to have for consumers of `ldk-swift` but not something that technically impedes the use of `ldk-swift`
- `ldk-swift` might only have included a `.binaryTarget` and no `.target` for good reason
- I think the `path` I put for the new `.target` is correct but let me know if not
- If we use `.target` we just have to figure out a different `name` in the `.target` than what I temporarily put ("LightningDevKitTarget"). 
  - ldk-node + bdk-swift + bdk-ffi use `XyzFFI` for the `name` of their `.binaryTarget` and then `Xyz` for the `name` of their `.target`
  - `ldk-swift` currently uses `Xyz` for the name of the `.binaryTarget`. I'm not sure if we'd want to change the name of `.binaryTarget` or not to add "FFI" to the end of it if it could cause problems for current consumers of the SDK, and I wasn't sure what we would want for the `.target` name if `LightningDevKit` was already taken by the `.binaryTarget`
- note: Xcode still has some weird bug(?) related to `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]` but it only shows up if you are importing a local package 
  - would not really effect consumers of `ldk-swift` other than if they were trying to make modifications to `ldk-swift` locally or something; 
  - if someone was using the remote swift package of `ldk-swift` they will not see that error/bug/etc. 
  - _Most people would not use `ldk-swift` as a local swift package imo_ If they did they would just need to comment out `swiftSettings: [.unsafeFlags(["-suppress-warnings"])]` in their local swift package