### PR TITLE
docs: add import LightningDevKit to setup.md

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -30,6 +30,7 @@ First, define an inheriting class called `MyFeeEstimator`:
 //  MyFeeEstimator.swift
 
 import Foundation
+import LightningDevKit
 
 class MyFeeEstimator: FeeEstimator {
 
@@ -57,6 +58,7 @@ Define the inheriting class:
 //  MyLogger.swift
 
 import Foundation
+import LightningDevKit
 
 class MyLogger: Logger {
 
@@ -83,6 +85,7 @@ Define the subclass:
 //  MyBroadcasterInterface.swift
 
 import Foundation
+import LightningDevKit
 
 class MyBroadcasterInterface: BroadcasterInterface {
 
@@ -110,6 +113,7 @@ Define the subclass:
 //  MyPersister.swift
 
 import Foundation
+import LightningDevKit
 
 class MyPersister: Persist {
 
@@ -150,6 +154,7 @@ Define the subclass:
 //  MyFilter.swift
 
 import Foundation
+import LightningDevKit
 
 class MyFilter: Filter {
 


### PR DESCRIPTION
Adds `import LightingDevKit` to the `docs/setup.md`

## **Describe The Feature**

Helping a `ldk-swift` user the other day in Discord they mentioned "in the examples btw should add the line import LightningDevKit" and added this screenshot:

![image](https://github.com/lightningdevkit/ldk-swift/assets/6657488/06579126-9120-4c97-9f54-8dcfd1140ba0)

## Why Add This Feature

Some users may take it as a given to add `import LightningDevKit` but some may not.

## Alternative Options

An alternative option to this is to add a one-liner at the top of the `setup.md` file saying to import LightningDevKit in any file you wish to use LDK.
